### PR TITLE
Merge: Update Docker ENTRYPOINT for SQLMesh UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,6 @@ WORKDIR /app/sqlmesh_project
 # Expose any port the SQLMesh app uses (replace with the correct port if needed)
 EXPOSE 8000
 
-# Run SQLMesh application (adjust the entry point based on your SQLMesh setup)
-CMD ["poetry", "run", "sqlmesh", "plan"]
+# Set the ENTRYPOINT to run Poetry and the SQLMesh UI by default
+ENTRYPOINT ["poetry", "run", "sqlmesh", "ui", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/README.md
+++ b/README.md
@@ -90,12 +90,10 @@ gateways:
       password: dev_password
 default_gateway: local
 
-## Contributing
+```
+### SQLmesh UI
+```
+http://localhost:8000
+```
 
-If you would like to contribute to this project, please follow these steps:
 
-1. Fork the repository.
-2. Create a new branch (`git checkout -b feature-branch`).
-3. Commit your changes (`git commit -m 'Add feature'`).
-4. Push to the branch (`git push origin feature-branch`).
-5. Open a Pull Request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-sqlmesh = {extras = ["postgres"], version = "^0.121.0"}
+sqlmesh = {extras = ["postgres", "web"], version = "^0.121.0"}
 
 
 


### PR DESCRIPTION
Hi Team ,

I have made the necessary adjustments to the Dockerfile in this pull request to ensure that the ENTRYPOINT is configured to run the SQLMesh UI by default. The changes include setting the command to:

```bash
poetry run sqlmesh ui --host 0.0.0.0 --port 8000
```

This update allows the container to automatically launch the SQLMesh UI on port 8000 when started, ensuring it is accessible from any host. The changes aim to streamline the setup process for using the SQLMesh UI directly.

Please review and merge the pull request if everything looks good.

Thank you!

Best regards,
Chinapat